### PR TITLE
Migrate features from WebchatClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "@types/node": {
       "version": "12.7.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
+      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+      "dev": true
     },
     "@types/socket.io-client": {
       "version": "1.4.32",
@@ -89,6 +90,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "detect-browser": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-4.8.0.tgz",
+      "integrity": "sha512-f4h2dFgzHUIpjpBLjhnDIteXv8VQiUm8XzAuzQtYUqECX/eKh67ykuiVoyb7Db7a0PUSmJa3OGXStG0CbQFUVw=="
     },
     "engine.io-client": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@types/node": "^12.7.1",
+    "detect-browser": "^4.8.0",
     "socket.io-client": "^2.2.0",
     "url": "^0.11.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@types/node": "^12.7.1",
     "@types/socket.io-client": "^1.4.32",
     "@types/uuid": "^3.4.4",
     "typescript": "^3.4.5"

--- a/src/helper/compatibility.ts
+++ b/src/helper/compatibility.ts
@@ -1,0 +1,13 @@
+import { detect } from "detect-browser";
+
+const browser = detect();
+
+export const shouldForceWebsockets = () => {
+    if (browser.name === 'ie')
+        return true;
+
+    if (browser.name === 'safari')
+        return true;
+
+    return false;
+}

--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -7,6 +7,7 @@ import { IProcessReplyPayload } from "./interfaces/output";
 import { Input } from "./interfaces/input";
 import { IFinalPing } from "./interfaces/finalPing";
 import { ITypingStatusPayload } from "./interfaces/typingStatus";
+import { shouldForceWebsockets } from "./helper/compatibility";
 
 export class SocketClient extends EventEmitter {
     public socketUrl: string;
@@ -29,7 +30,7 @@ export class SocketClient extends EventEmitter {
 
             // connection behaviour
             expiresIn: null,
-            forceWebsockets: false,
+            forceWebsockets: shouldForceWebsockets(),
             interval: 10000,
             passthroughIP: null,
             reconnection: true,


### PR DESCRIPTION
The goal of this PR is to move certain features of @cognigy/webchat-client here.

Those features are:
- setting the `forceWebsockets` option default based on the environment used