### PR TITLE
Feature/force polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This package is used to create a connection to Cognigy.AI via a Socket Endpoint.
 You can read about setting up a Socket Endpoint in [our platform documentation](https://docs.cognigy.com/docs/deploy-a-socket-endpoint)
 
 ## Installation
+
 Install this module using the following `npm` command
+
 ```
 npm install @cognigy/socket-client
 ```
@@ -12,63 +14,66 @@ npm install @cognigy/socket-client
 ## Usage
 
 ```javascript
-const { SocketClient } = require('@cognigy/socket-client');
+const { SocketClient } = require("@cognigy/socket-client");
 
 (async () => {
-    // create a client instance with a socket url and an url token
-    const client = new SocketClient('https://socket.url', 'socket-token', {
-      // if you use node, internet explorer or safari, you need to enforce websockets
-      forceWebsockets: true
-    });
+  // create a client instance with a socket url and an url token
+  const client = new SocketClient("https://socket.url", "socket-token", {
+    // if you use node, internet explorer or safari, you need to enforce websockets
+    forceWebsockets: true,
+  });
 
-    // register a handler for messages
-    client.on('output', output => {
-        console.log("Text: " + output.text + "   Data: " + output.data);
-    });
+  // register a handler for messages
+  client.on("output", (output) => {
+    console.log("Text: " + output.text + "   Data: " + output.data);
+  });
 
-    // establish a socket connection (returns a promise)
-    await client.connect();
-    
-    // send a message with text, text and data, data only
-    client.sendMessage('hello there');
-    client.sendMessage('hello there', { color: 'green' });
-    client.sendMessage('', { color: 'green' });
-})()
+  // establish a socket connection (returns a promise)
+  await client.connect();
+
+  // send a message with text, text and data, data only
+  client.sendMessage("hello there");
+  client.sendMessage("hello there", { color: "green" });
+  client.sendMessage("", { color: "green" });
+})();
 ```
-> In case you are using TypeScript in a frontend codebase, you may need to manually install `@types/node` to avoid transpilation errors regarding event-related code parts like e.g. `client.on()` 
+
+> In case you are using TypeScript in a frontend codebase, you may need to manually install `@types/node` to avoid transpilation errors regarding event-related code parts like e.g. `client.on()`
 
 ## Socket Events
+
 You can subscribe to the following events from the `SocketClient`:
 
 ```javascript
-client.on('finalPing', () => {
-    console.log('bot is done processing a message');
+client.on("finalPing", () => {
+  console.log("bot is done processing a message");
 });
-
 ```
-| Name | Event Payload | Description |
-| - | - | - |
-| output | `{ text, data }` | fires on every incoming message from the bot
-| typingStatus | `"on"` or `"off"` | fires when the typing indicator should show or hide
-| finalPing | - | fires when the bot is done processing a message
-| error | `{ message }` | fires when an error happened in the bot
+
+| Name         | Event Payload     | Description                                         |
+| ------------ | ----------------- | --------------------------------------------------- |
+| output       | `{ text, data }`  | fires on every incoming message from the bot        |
+| typingStatus | `"on"` or `"off"` | fires when the typing indicator should show or hide |
+| finalPing    | -                 | fires when the bot is done processing a message     |
+| error        | `{ message }`     | fires when an error happened in the bot             |
 
 ## Options
+
 You can pass a third argument to `SocketClient` to set additional options as follows:
 
 ```javascript
-const client = new SocketClient('https://socket.url', 'socket-token', {
-    userId: 'user1234'
+const client = new SocketClient("https://socket.url", "socket-token", {
+  userId: "user1234",
 });
 ```
 
-| Name | Type | Default | Description '
-| - | - | - | - |
-| `userId` | string | random string | the user id for the conversation
-| `sessionId` | string | random string | the session id for the conversation
-| `channel` | string | `"socket-client"` | the name of the channel (can be used for analytics purposes)
-| `forceWebsockets` | boolean | `false` | if this is enabled, there will be no fallback to http polling
-| `interval` | number | `10000` | the interval for polling if in http polling fallback
-| `reconnection` | boolean | `true` | if enabled, will try to reconnect if the connection is aborted
-| `reconnectionLimit` | number | `5` | limit the maximum number of reconnection attempts, `0` means no limit
-
+| Name                | Type    | Default                                | Description '                                                                            |
+| ------------------- | ------- | -------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `userId`            | string  | random string                          | the user id for the conversation                                                         |
+| `sessionId`         | string  | random string                          | the session id for the conversation                                                      |
+| `channel`           | string  | `"socket-client"`                      | the name of the channel (can be used for analytics purposes)                             |
+| `forceWebsockets`   | boolean | auto-determined by runtime-environment | if this is enabled, there will be no fallback to http polling (wins over `forcePolling`) |
+| `forcePolling`      | boolean | `false`                                | if this is enabled, there will be no upgrade to websockets                               |
+| `interval`          | number  | `10000`                                | the interval for polling if in http polling fallback                                     |
+| `reconnection`      | boolean | `true`                                 | if enabled, will try to reconnect if the connection is aborted                           |
+| `reconnectionLimit` | number  | `5`                                    | limit the maximum number of reconnection attempts, `0` means no limit                    |

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ const client = new SocketClient("https://socket.url", "socket-token", {
 });
 ```
 
-| Name                | Type    | Default                                | Description '                                                                            |
-| ------------------- | ------- | -------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `userId`            | string  | random string                          | the user id for the conversation                                                         |
-| `sessionId`         | string  | random string                          | the session id for the conversation                                                      |
-| `channel`           | string  | `"socket-client"`                      | the name of the channel (can be used for analytics purposes)                             |
-| `forceWebsockets`   | boolean | auto-determined by runtime-environment | if this is enabled, there will be no fallback to http polling (wins over `disableWebsockets`) |
-| `disableWebsockets` | boolean | `false`                                | if this is enabled, there will be no upgrade to websockets                               |
-| `interval`          | number  | `10000`                                | the interval for polling if in http polling fallback                                     |
-| `reconnection`      | boolean | `true`                                 | if enabled, will try to reconnect if the connection is aborted                           |
-| `reconnectionLimit` | number  | `5`                                    | limit the maximum number of reconnection attempts, `0` means no limit                    |
+| Name                | Type    | Default                                | Description '                                                                                                             |
+| ------------------- | ------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `userId`            | string  | random string                          | the user id for the conversation                                                                                          |
+| `sessionId`         | string  | random string                          | the session id for the conversation                                                                                       |
+| `channel`           | string  | `"socket-client"`                      | the name of the channel (can be used for analytics purposes)                                                              |
+| `forceWebsockets`   | boolean | auto-determined by runtime-environment | If this is enabled, the client will only use websockets and not fall back to http polling (wins over `disableWebsockets`) |
+| `disableWebsockets` | boolean | `false`                                | If this is enabled, the client will only use http polling and will not try to upgrade to websockets                       |
+| `interval`          | number  | `10000`                                | the interval for polling if in http polling fallback                                                                      |
+| `reconnection`      | boolean | `true`                                 | if enabled, will try to reconnect if the connection is aborted                                                            |
+| `reconnectionLimit` | number  | `5`                                    | limit the maximum number of reconnection attempts, `0` means no limit                                                     |

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ const client = new SocketClient("https://socket.url", "socket-token", {
 | `userId`            | string  | random string                          | the user id for the conversation                                                         |
 | `sessionId`         | string  | random string                          | the session id for the conversation                                                      |
 | `channel`           | string  | `"socket-client"`                      | the name of the channel (can be used for analytics purposes)                             |
-| `forceWebsockets`   | boolean | auto-determined by runtime-environment | if this is enabled, there will be no fallback to http polling (wins over `forcePolling`) |
-| `forcePolling`      | boolean | `false`                                | if this is enabled, there will be no upgrade to websockets                               |
+| `forceWebsockets`   | boolean | auto-determined by runtime-environment | if this is enabled, there will be no fallback to http polling (wins over `disableWebsockets`) |
+| `disableWebsockets` | boolean | `false`                                | if this is enabled, there will be no upgrade to websockets                               |
 | `interval`          | number  | `10000`                                | the interval for polling if in http polling fallback                                     |
 | `reconnection`      | boolean | `true`                                 | if enabled, will try to reconnect if the connection is aborted                           |
 | `reconnectionLimit` | number  | `5`                                    | limit the maximum number of reconnection attempts, `0` means no limit                    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+      "version": "12.19.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.14.tgz",
+      "integrity": "sha512-2U9uLN46+7dv9PiS8VQJcHhuoOjiDPZOLAt0WuA1EanEknIMae+2QbMhayF7cgGqjvRVIfNpt+6jLPczJZFiRw==",
       "dev": true
     },
     "@types/socket.io-client": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@types/node": "^12.7.1",
+    "@types/node": "^12.19.14",
     "@types/socket.io-client": "^1.4.32",
     "@types/uuid": "^3.4.4",
     "typescript": "^3.4.5"

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -20,8 +20,12 @@ export interface Options {
 
 	passthroughIP?: string;
 
-	/**
+	/** 
 	 * Whether to force a websocket connection.
+	 * Will win over "forcePolling" if both are set to true.
 	 */
 	forceWebsockets: boolean;
+
+	/** Whether to force HTTP polling */
+	forcePolling: boolean;
 };

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -26,6 +26,6 @@ export interface Options {
 	 */
 	forceWebsockets: boolean;
 
-	/** Whether to force HTTP polling */
-	forcePolling: boolean;
+	/** Whether to only rely on HTTP polling */
+	disableWebsockets: boolean;
 };

--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -55,7 +55,7 @@ export class SocketClient extends EventEmitter {
         /**
          * If no explicit polling or websockets flag was set,
          * decide implicitly on whether to force websockets
-         * based on the runtime enrivonment.
+         * based on the runtime environment.
          */
         if (!options.forceWebsockets && !options.disableWebsockets) {
             mergedOptions.forceWebsockets = shouldForceWebsockets();

--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -178,8 +178,6 @@ export class SocketClient extends EventEmitter {
             connectOptions.upgrade = false;
         }
 
-        console.log(this.socketOptions, connectOptions);
-
         const socket = SocketIOClient.connect(parsedUrl.origin, connectOptions);
 
         // forward Socket.IO events

--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -31,7 +31,7 @@ export class SocketClient extends EventEmitter {
             // connection behaviour
             expiresIn: null,
             forceWebsockets: false,
-            forcePolling: false,
+            disableWebsockets: false,
             interval: 10000,
             passthroughIP: null,
             reconnection: true,
@@ -57,7 +57,7 @@ export class SocketClient extends EventEmitter {
          * decide implicitly on whether to force websockets
          * based on the runtime enrivonment.
          */
-        if (!options.forceWebsockets && !options.forcePolling) {
+        if (!options.forceWebsockets && !options.disableWebsockets) {
             mergedOptions.forceWebsockets = shouldForceWebsockets();
         }
 
@@ -166,14 +166,15 @@ export class SocketClient extends EventEmitter {
         };
 
         /**
-         * If websockets or polling is forced by flag,
+         * If websockets are forced or disabled,
          * change the transport and upgrade flags accordingly.
          * 
-         * In case both options are provided, websockets win over polling.
+         * In case both options are provided, forcing websockets
+         * wins over disabling websockets.
          */
         if (this.socketOptions.forceWebsockets) {
             connectOptions.transports = ["websocket"];
-        } else if (this.socketOptions.forcePolling) {
+        } else if (this.socketOptions.disableWebsockets) {
             connectOptions.transports = ["polling"];
             connectOptions.upgrade = false;
         }


### PR DESCRIPTION
This adds a `forcePolling` option to the connection options.

If it's set, it will force HTTP polling and will not try to upgrade to WebSockets later-on.
Only one of `forcePolling` and `forceWebsockets` should be set at a time since they exclude each other.
In case both are set, the `forceWebsockets` option will win.