### PR TITLE
Reconnect with url query parameters

### DIFF
--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -121,7 +121,8 @@ export class SocketClient extends EventEmitter {
                 if (!this.connected && !this.shouldStopReconnecting()) {
                     this.registerReconnectionAttempt();
                     try {
-                        await this.connect(true);
+                        const isReconnect = true;
+                        await this.connect(isReconnect);
                         console.log(`[SocketClient] Successfully reconnected.`);
                     } catch (err) {
                         console.error(`[SocketClient] Failed to reconnect, error was: ${JSON.stringify(err)}`);

--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -187,6 +187,7 @@ export class SocketClient extends EventEmitter {
         if (isReconnect) {
             connectOptions["query"] = {
                 sessionId: encodeURIComponent(this.socketOptions.sessionId),
+                urlToken: encodeURIComponent(this.socketURLToken),
                 userId: encodeURIComponent(this.socketOptions.userId),
             }
         }


### PR DESCRIPTION
This PR adds sessionId/userId to the query parameters on reconnecting attempt.

To test:
- establish a connection (e.g. by linking SocketClient to the Webchat)
- open network panel in browser
- break you internet connection
- wait for the previous websocket to close
- reconnect with internet
new webSocket connection should contain userId and sessionId in the url query