### PR TITLE
always provide userId and sessionId on connect

### DIFF
--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -178,15 +178,14 @@ export class SocketClient extends EventEmitter {
         }
 
         /**
-         * If this is a reconnection attempt,
-         * we send sessionId, userId inside a query parameter
+         * Identify this endpoint to the endpoint for session-to-socket mapping.
+         * Without this, the backend cannot "take first steps" because it can't
+         * reach the client!
          */
-        if (isReconnect) {
-            connectOptions["query"] = {
-                sessionId: encodeURIComponent(this.socketOptions.sessionId),
-                urlToken: encodeURIComponent(this.socketURLToken),
-                userId: encodeURIComponent(this.socketOptions.userId),
-            }
+        connectOptions["query"] = {
+            sessionId: encodeURIComponent(this.socketOptions.sessionId),
+            urlToken: encodeURIComponent(this.socketURLToken),
+            userId: encodeURIComponent(this.socketOptions.userId),
         }
 
         const socket = SocketIOClient.connect(parsedUrl.origin, connectOptions);


### PR DESCRIPTION
This PR fixes an issue where the client cannot be reached by the backend (e.g. using inject/notify/live agent) before the client sent its first message. By providing userId/sessionId in the connection query parameters, we have the session-to-socket mapping from the beginning.

To test this, create a socket endpoint and use the "inject" API after connecting the socket-client.
Here's some example code for validation:
```typescript
import { SocketClient } from "./socket-client";

(async () => {
  const userId = "user3";
  const sessionId = "session3";

  const client = new SocketClient(
    "http://endpoint",
    "372e340d5e4bf2fc2e616ca4683c2cc4de6824f61cbc82a8d70c8534553a6b91",
    {
      userId,
      sessionId,
    }
  );

  await client.connect();

  console.log("connected", { userId, sessionId });

  client.on("output", console.log);
})();

```