### PR TITLE
added support for "finalPing" events on v4

### DIFF
--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -212,7 +212,15 @@ export class SocketClient extends EventEmitter {
 
         // pass through basic events
         socket.on("exception", (error: any) => this.emit('exception', error));
-        socket.on("typingStatus", (payload: ITypingStatusPayload) => this.emit('typingStatus', payload));   
+        socket.on("typingStatus", (payload: ITypingStatusPayload) => this.emit('typingStatus', payload));
+
+        /**
+         * Heads up!
+         * 
+         * On v3 environments, we're publishing the "finalPing" as an "output" event with "type: finalPing",
+         * on v4 environments, we're directly publishing the "finalPing" as a "finalPing" event!
+         */
+        socket.on("finalPing", (reply: any) => this.emit('finalPing', reply));
 
         // decide positive / negative outcome of output based on content
         socket.on("output", (reply: IProcessReplyPayload) => {


### PR DESCRIPTION
This PR fixes an issue where the client would not emit `finalPing` events when interacting with a Cognigy.AI v4 environment.
The expected outcome is that you can subscribe to `client.on('finalPing')` and receive the same payload for both cases, v3 and v4.
I set up two identical bots on `dev` and `dev-v4` and used the following code to validate they both work the same way:

```javascript
import { SocketClient } from "./socket-client";

const checkFinalPing = async (url, token) => {
  const alias = `${url}/${token}`;
  const client = new SocketClient(url, token);

  await client.connect();

  return Promise.race([
    new Promise((resolve) => {
      client.once("finalPing", (event) => {
        console.log(event);
        resolve(`${alias} succeeded!`);
      });

      client.sendMessage("test");
    }),
    new Promise((resolve) =>
      setTimeout(() => resolve(`${alias} failed!`), 1000)
    ),
  ]).then(console.log.bind(console));
};

(async () => {
  await checkFinalPing(
    "https://endpoint-dev.cognigy.ai",
    "0e7ff8bda42b502789f871f84e2584e1a15c0e234421a13ca8a4fa4173911e81"
  );
  await checkFinalPing(
    "https://endpoint-dev-v4.cognigy.ai",
    "5a81813572ac5a2feafae8f91b88778ab5afb89a81323da1fc44791a2110d43a"
  );
})();
```