### PR TITLE
fixed dead docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cognigy Socket Client
 
 This package is used to create a connection to Cognigy.AI via a Socket Endpoint.  
-You can read about setting up a Socket Endpoint in [our platform documentation](https://docs.cognigy.com/docs/deploy-a-socket-endpoint)
+You can read about setting up a Socket Endpoint in [our platform documentation](https://docs.cognigy.com/ai/endpoints/socketio/)
 
 ## Installation
 


### PR DESCRIPTION
the "out platform documentation" link was broken and I changed it to the new equivalent of the docs page we used to have.