### PR TITLE
Change controlCommands prop to an array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "5.0.0-beta.9",
+  "version": "5.0.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognigy/socket-client",
-      "version": "5.0.0-beta.9",
+      "version": "5.0.0-beta.10",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "detect-browser": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "5.0.0-beta.9",
+  "version": "5.0.0-beta.10",
   "description": "A client used to connect to Cognigy installations through Socket-Endpoints",
   "author": "Robin Schuster <r.schuster@cognigy.com>",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/interfaces/messageData.ts
+++ b/src/interfaces/messageData.ts
@@ -22,7 +22,7 @@ export interface ICognigyData {
 	_plugin?: unknown;
 	_facebook?: IWebchatMessage;
 	syncWebchatWithFacebook?: boolean;
-	controlCommands?: ISetRatingControlCommand
+	controlCommands?: ISetRatingControlCommand[];
 }
 
 export interface IPluginDatepicker {


### PR DESCRIPTION
Fixed a bug where controlCommands prop was incorrectly typed as ISetRatingControlCommand instead of array of ISetRatingControlCommand