### PR TITLE
Separate IMessage interface

### DIFF
--- a/src/interfaces/messageData.ts
+++ b/src/interfaces/messageData.ts
@@ -1,12 +1,21 @@
 import { IAdaptiveCard } from 'adaptivecards';
 
-export interface IMessage {
+/**
+ * 
+ * Fields used by chat-components and currently added by the Webchat Client. 
+ * Expected to be present in the socket message sent by endpoint at some point.
+*/
+export interface IWebchatClientMessage {
+	avatarUrl?: string;
+	avatarName?: string;
+	timestamp?: string;
+}
+// We temporary extend IMessage with IWebchatClientMessage
+// to avoid making changes in the codebase. See prev. comment.
+export interface IMessage extends IWebchatClientMessage{
 	text?: string | null;
 	data?: IMessageData;
 	source?: "user" | "bot" | "engagement" | "agent";
-	timestamp?: string;
-	avatarUrl?: string;
-	avatarName?: string;
 	disableSensitiveLogging?: boolean;
 	traceId?: string;
 };


### PR DESCRIPTION
Adds temporary interface separation of IMessage interface. Some fields are currently missing from a message received from the v3 endpoint.

To test:
```sh
npm ci && npm run build && npm pack && cd ../WebchatWidget && npm i cognigy-socket-client-5.0.0-beta.10.tgz
```
The Webchat should build

*Note: not bumping version as its a non-breaking, non-functional change in beta release branch.*