### PR TITLE
reset endpoint readiness state on (re)connect

### DIFF
--- a/src/socket-client.ts
+++ b/src/socket-client.ts
@@ -331,6 +331,10 @@ export class SocketClient extends EventEmitter {
             }
 
             socket.on("connect", () => {
+                // reset "endpoint ready" state
+                // in case we reconnected
+                this._isEndpointReady = false;
+
                 this.socket = socket;
 
                 // if configured, initialize automatic reconnect attempts


### PR DESCRIPTION
in case of a reconnection, the "endpoint ready" state is `false` until we get the event again. This could lead to situations where messages are not properly buffered