### PR TITLE
patch 4.8.1 - wait for `"endpoint-ready"` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ const { SocketClient } = require("@cognigy/socket-client");
 
 > In case you are using TypeScript in a frontend codebase, you may need to manually install `@types/node` to avoid transpilation errors regarding event-related code parts like e.g. `client.on()`
 
+
+## Compatibility
+
+| SocketClient | Cognigy.AI | Note |
+| - | - | - |
+| >= `v4.8.1` | >= `v4.79.0` | Starting with SocketClient version `v4.8.1`, the client waits for an `"endpoint-ready"` event during `connect()` which is only emitted by Endpoints from Cognigy.AI version `v4.79.0` or later!
+| <= `v4.8.0` | `*` |
+
 ## Socket Events
 
 You can subscribe to the following events from the `SocketClient`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "A client used to connect to Cognigy installations through Socket-Endpoints",
   "author": "Robin Schuster <r.schuster@cognigy.com>",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
This PR bumps the version to `4.8.1`, improving the connectivity behavior to rely on the new `"endpoint-ready"` event that is introduced in Cognigy.AI `v4.79.0`. Since the client is not backwards-compatible with old Cognigy.AI-versions, we added a compatibility table to the README file.