### PR TITLE
Bug/76068 sync v5 with main to fix bugs

### DIFF
--- a/.azuredevops/pull_request_template.md
+++ b/.azuredevops/pull_request_template.md
@@ -1,0 +1,25 @@
+# Success criteria
+Please describe what should be possible after this change. List all individual items on a separate line.
+
+- A
+- B
+- C
+
+# How to test
+Please describe the individual steps on how a peer can test your change.
+
+1. A
+2. B
+3. C
+
+# Security
+- [ ] Possible injection vector
+- [ ] Authentication/Access controls touched
+- [ ] Sensitive Data could be exposed
+- [ ] XSS
+- [ ] Logging/Monitoring touched
+- [ ] Exchanges data with external systems
+- [ ] No security implications
+
+# Additional considerations
+- [ ] This PR might have performance implications

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -40,4 +40,13 @@ export interface Options {
 	 * test messages without increasing the billable conversation count.
 	 */
 	testMode: boolean;
+
+	/**
+	 * If this is enabled, this`emitWithAck` parameter with be passed to socket connection.
+	 * And socket.io endpoint will emit messages with acknowledgement. This will be useful when event buffering feature is enabled
+	 * and network goes of, in lack of "acknowledgement" back to socket endpoint, message delivery is considered to be failed.
+	 * 
+	 * This is enabled by default and only used when "event buffering feature is enabled".
+	 */
+	emitWithAck: boolean;
 };


### PR DESCRIPTION
This PR syncs the socket-client changes that were there in master but missed in v5-for-webchat-v3 branch.

Success Criteria
- The changes in the following PRs should be there
https://github.com/Cognigy/SocketClient/pull/37
https://github.com/Cognigy/SocketClient/pull/41
https://github.com/Cognigy/SocketClient/pull/42 
- Should be able to send and receive messages in Webchat
- If a sessionId is assigned and the webchat is refreshed in the middle of the conversation, the conversation should still remain in the chat history when clicking 'Start Conversation' after webchat reload.

How to test
- Deploy the branch and do npm ci && npm run build
- Pack the socket-client by doing npm pack
- Open the main branch in Webchat repo and install the packed socket client by doing npm i <PATH_TO_THE_PACKED_FILE>
- Please do an overall sanity check. 