### PR TITLE
4.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "4.8.3",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognigy/socket-client",
-      "version": "4.8.3",
+      "version": "4.9.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "detect-browser": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "4.8.3",
+  "version": "4.9.0",
   "description": "A client used to connect to Cognigy installations through Socket-Endpoints",
   "author": "Robin Schuster <r.schuster@cognigy.com>",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
This PR updates the version of socket-client to 4.9.0 for webchat v2. 

It contains the following improvement:
- Update node to v22 in #56 by @vj-venkatesan 