### PR TITLE
tech: #92081 update socket.io-client and related dependencies to late…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -185,9 +185,9 @@
       "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
     },
     "node_modules/parseuri": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-3.0.2.tgz",
+      "integrity": "sha512-eNmfF+mj9fyyZFFW9keXPsIscduBQub8oqnXXPYnl6hGs6P0mshf9ArriI9vB6w08GuuzgQnTWRrWWDTeoCLEQ=="
     },
     "node_modules/punycode": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "engines": {
     "node": ">=22.1.0"
+  },
+  "overrides": {
+    "parseuri":">=3.0.1"
   }
 }


### PR DESCRIPTION
This PR fixes the vulnerability threat reported by Vanta (See [ticket](https://cognigy.visualstudio.com/Boron/_workitems/edit/92081) for more details).

The security vulnerability can also be found [here](https://github.com/Cognigy/SocketClient/security/dependabot/5)

This is fixed by adding 3.0.2 version of parseuri in the overrides section of package.json