### PR TITLE
Revert "chore: override parseuri to fix security vulnerability"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -185,9 +185,9 @@
       "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
     },
     "node_modules/parseuri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-3.0.2.tgz",
-      "integrity": "sha512-eNmfF+mj9fyyZFFW9keXPsIscduBQub8oqnXXPYnl6hGs6P0mshf9ArriI9vB6w08GuuzgQnTWRrWWDTeoCLEQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
     },
     "node_modules/punycode": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
   },
   "engines": {
     "node": ">=22.1.0"
-  },
-  "overrides": {
-    "parseuri": ">=3.0.1"
   }
 }


### PR DESCRIPTION
This reverts commit a7e89939e0a7ee6222d07dcab7d690e28bf15882.

The above commit was made in the hope of fixing this vulnerability https://github.com/advisories/GHSA-6fx8-h7jm-663j

However the  commit has to be reverted since the overridden version of parseuri breaks Webchat v2 socket connection. This is not directly affecting V2 in production since the override did not actually override when socket-client was installed in v2. 

The version of parseuri containing security fix seems to have changed from commonjs to es6 which breaks the entire socket connection in v2. Thus reverting this PR and also in the future until webchat v2 is deprecated we will have to live with this vulnerability as there is no direct remediation path for this