### PR TITLE
Fix throwing on iOS in-app-browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "5.0.0-beta.22",
+  "version": "5.0.0-beta.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognigy/socket-client",
-      "version": "5.0.0-beta.22",
+      "version": "5.0.0-beta.23",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "detect-browser": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognigy/socket-client",
-  "version": "5.0.0-beta.22",
+  "version": "5.0.0-beta.23",
   "description": "A client used to connect to Cognigy installations through Socket-Endpoints",
   "author": "Robin Schuster <r.schuster@cognigy.com>",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/helper/compatibility.ts
+++ b/src/helper/compatibility.ts
@@ -3,6 +3,9 @@ import { detect } from "detect-browser";
 const browser = detect();
 
 export const shouldForceWebsockets = () => {
+  // ios in-app browser case
+  if (!browser) return true;
+  
     switch (browser.name) {
         // Internet Explorer
         case 'ie':


### PR DESCRIPTION
Browser detection was failing in iOS in-app-browser leading to exception. This PR fixes this.

To test:
- build & pack
- install into Webchat
- in Chrome, Network panel, Network conditions, custom agent string: 
`Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) (BathAndBodyWorks; iOS; 8.0.1)`

Webchat should work.