### PR TITLE
feat: add npm trusted publishing with OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+# =============================================================================
+# @cognigy/socket-client - Publish to npm
+# =============================================================================
+# Triggered on push to main branch.
+# Builds the package and publishes to npm using trusted publishing (OIDC).
+# =============================================================================
+
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write # Required for npm trusted publishing (OIDC)
+  contents: read
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      # ----------------------------------------------------------------------
+      # Checkout the repository
+      # ----------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ----------------------------------------------------------------------
+      # Setup Node.js with npm registry (Node 24 includes npm 11.5.1+)
+      # ----------------------------------------------------------------------
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      # ----------------------------------------------------------------------
+      # Install dependencies
+      # ----------------------------------------------------------------------
+      - name: Install dependencies
+        run: npm ci
+
+      # ----------------------------------------------------------------------
+      # Build the package
+      # ----------------------------------------------------------------------
+      - name: Build
+        run: npm run build
+
+      # ----------------------------------------------------------------------
+      # Publish to npm using OIDC (no token needed)
+      # ----------------------------------------------------------------------
+      - name: Publish to npm
+        run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # @cognigy/socket-client - Publish to npm
 # =============================================================================
-# Triggered on push to main branch.
+# Triggered when a version tag (v*) is pushed.
 # Builds the package and publishes to npm using trusted publishing (OIDC).
 # =============================================================================
 
@@ -9,8 +9,8 @@ name: Publish to npm
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A client used to connect to Cognigy installations through Socket-Endpoints",
   "author": "Robin Schuster <r.schuster@cognigy.com>",
   "license": "SEE LICENSE IN LICENSE",
+  "url": "https://github.com/Cognigy/SocketClient",
   "main": "lib/socket-client.js",
   "types": "lib/socket-client",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A client used to connect to Cognigy installations through Socket-Endpoints",
   "author": "Robin Schuster <r.schuster@cognigy.com>",
   "license": "SEE LICENSE IN LICENSE",
-  "url": "https://github.com/Cognigy/SocketClient",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cognigy/SocketClient"
+  },
   "main": "lib/socket-client.js",
   "types": "lib/socket-client",
   "scripts": {


### PR DESCRIPTION
# Success criteria
- Packages can be published to npm using OIDC authentication (trusted publishing)
- No long-lived npm tokens are required in GitHub secrets
- Provenance attestations are automatically generated for published packages
- New publish workflow triggers on push to main branch

# How to test
1. Configure trusted publisher on npmjs.com for this package:
   - Organization: `Cognigy`
   - Repository: `SocketClient`
   - Workflow filename: `publish.yml`
2. Merge this PR and push to main
3. Verify the package is published successfully without npm tokens

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations
- [ ] This PR might have performance implications

# Documentation Considerations
These are hints for the documentation team to help write the docs.